### PR TITLE
Remove comma from category, tiny Markdown change

### DIFF
--- a/_posts/2015-10-02-Chuxiong-Snaps.markdown
+++ b/_posts/2015-10-02-Chuxiong-Snaps.markdown
@@ -1,20 +1,20 @@
 ---
 layout: post
 title:  "Snaps: Chuxiong 楚雄"
-description: 
+description:
 date:   2015-10-02 01:33:00
-categories: photography, China
+categories: photography China
 ---
 
 <a data-flickr-embed="true"  href="https://www.flickr.com/photos/136459740@N03/albums/72157658953713439" title="Chuxiong, Yunnan, China"><img src="https://farm1.staticflickr.com/669/21787478532_67579b2d7c_c.jpg" width="800" height="600" alt="Chuxiong, Yunnan, China"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
-#I will continue to add photos to this album as I snap them!#
+# I will continue to add photos to this album as I snap them!
 
-This is Chuxiong. I've been living in this city for over a year now, and have grown to enjoy all its subtle and less subtle quirks. Around 500 thousand people call Chuxiong home. It's the capitol of Chuxiong Yi People Autonomous Region, so many people here are part of the Yi ethnic minority. 
+This is Chuxiong. I've been living in this city for over a year now, and have grown to enjoy all its subtle and less subtle quirks. Around 500 thousand people call Chuxiong home. It's the capitol of Chuxiong Yi People Autonomous Region, so many people here are part of the Yi ethnic minority.
 
 Tobacco is the main industry for this region. The wealthiest in the city all live and work at the Yunyan factory district, which also houses the nicest basketball courts in town. Honey, walnuts, and wild mushrooms are also specialty products here.
 
-The local dialect sounds like a rougher, grittier Mandarin. Some words seem to be randomly pronounced differently but if spoken slowly enough one can get the gist of most conversations without too much trouble. 
+The local dialect sounds like a rougher, grittier Mandarin. Some words seem to be randomly pronounced differently but if spoken slowly enough one can get the gist of most conversations without too much trouble.
 
 Chuxiong is either really dry or pouring rain. Rainy season starts in the spring and ends with monsoonal showers in the summer.
 

--- a/_posts/2015-10-20-Shaxi-Snaps.markdown
+++ b/_posts/2015-10-20-Shaxi-Snaps.markdown
@@ -1,19 +1,19 @@
 ---
 layout: post
 title:  "Snaps: Shaxi 大理沙溪古镇"
-description: 
+description:
 date:   2015-10-20 10:33:00
-categories: photography, China
+categories: photography China
 ---
 
 <a data-flickr-embed="true"  href="https://www.flickr.com/photos/136459740@N03/albums/72157660131292911" title="Shaxi"><img src="https://farm1.staticflickr.com/738/22028140101_298f309e98_c.jpg" width="800" height="600" alt="Shaxi"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
-#I will continue to add photos to this album as I snap them!#
+# I will continue to add photos to this album as I snap them!
 
 Shaxi is about a 4 hour journey from Xiaguan (main Dali transport hub). It's a complicated trip, but totally worth it.
 
-Shaxi is the most comfortable place I have traveled to in China. It's quiet, beautiful, reasonably priced, and still has that authentic feel that's lost in other "Old Towns." 
+Shaxi is the most comfortable place I have traveled to in China. It's quiet, beautiful, reasonably priced, and still has that authentic feel that's lost in other "Old Towns."
 
-Similar to Xizhou, you can rent bicycles for 30rmb a day and explore the surrounding villages, farms and mountains. We elected to just hang out in town and enjoy the food and company. 
+Similar to Xizhou, you can rent bicycles for 30rmb a day and explore the surrounding villages, farms and mountains. We elected to just hang out in town and enjoy the food and company.
 
 Randomly, there's also a lot of pets and strays in Shaxi. Most of my "Cute pets and strays" album is from here.

--- a/_posts/2015-10-20-Xizhou-Snaps.markdown
+++ b/_posts/2015-10-20-Xizhou-Snaps.markdown
@@ -1,14 +1,14 @@
 ---
 layout: post
 title:  "Snaps: Xizhou 大理喜州古镇"
-description: 
+description:
 date:   2015-10-20 10:33:00
-categories: photography, China
+categories: photography China
 ---
 
 <a data-flickr-embed="true"  href="https://www.flickr.com/photos/136459740@N03/albums/72157660099552062" title="Xizhou"><img src="https://farm1.staticflickr.com/762/21395030223_58e3369b1c_c.jpg" width="800" height="600" alt="Xizhou"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
-#I will continue to add photos to this album as I snap them!#
+# I will continue to add photos to this album as I snap them!
 
 Xizhou is a touristy little village near Dali Old Town. The trinkets and crowds can be overwhelming in the village itself, but adventure and fun awaits those who rent bikes and journey around the nearby Erhai Lake from which Xizhou is satellite.
 

--- a/_posts/2015-10-21-Baoshan-Snaps.markdown
+++ b/_posts/2015-10-21-Baoshan-Snaps.markdown
@@ -3,16 +3,16 @@ layout: post
 title:  "Snaps: Baoshan 保山"
 description: Gateway to the mountains
 date:   2015-10-21 10:33:00
-categories: photography, China
+categories: photography China
 ---
 
 <a data-flickr-embed="true"  href="https://www.flickr.com/photos/136459740@N03/albums/72157660132809155" title="Baoshan"><img src="https://farm1.staticflickr.com/620/21826630199_786f8d078f_c.jpg" width="800" height="600" alt="Baoshan"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
-#I will continue to add photos to this album as I snap them!#
+# I will continue to add photos to this album as I snap them!
 
 This is Baoshan. A wonderfully diverse city. It's really hard to put a finger on the exact characteristics... but it keeps surprising us in the best ways.
 
-My favorite restaurant is in Baoshan. You can get the best foot soak and massage of your life in Baoshan. You can get fruit juices (mango, papaya, dragonfruit, pineapple) for only 6 rmb at the Burmese restaurant in Baoshan. If you look foreign enough you can get free drinks at the syndicate-run nightclub in Baoshan. 
+My favorite restaurant is in Baoshan. You can get the best foot soak and massage of your life in Baoshan. You can get fruit juices (mango, papaya, dragonfruit, pineapple) for only 6 rmb at the Burmese restaurant in Baoshan. If you look foreign enough you can get free drinks at the syndicate-run nightclub in Baoshan.
 
 Baoshan is the gateway to the mountains. Many tucked-away mountain countys in Yunnan will feed into Baoshan before continuing along the G56 highway. A convergence of cultures. Baoshan might not be the most aesthetic city, but we keep coming back here. It's unique, central, and just what we need after long weeks of teaching in our villages (or city, in my case).
 

--- a/_posts/2015-10-21-Pets-Snaps.markdown
+++ b/_posts/2015-10-21-Pets-Snaps.markdown
@@ -1,17 +1,17 @@
 ---
 layout: post
 title:  "Snaps: Pets and Strays"
-description: 
+description:
 date:   2015-10-21 10:33:00
-categories: photography, China
+categories: photography China
 ---
 
 <a data-flickr-embed="true"  href="https://www.flickr.com/photos/136459740@N03/albums/72157659591218285" title="Cute pets and strays"><img src="https://farm1.staticflickr.com/674/21442323474_24ed83a475_c.jpg" width="800" height="600" alt="Cute pets and strays"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
-#I will continue to add photos to this album as I snap them!#
+# I will continue to add photos to this album as I snap them!
 
 There are a lot of strays in China... some of the bravest animals I have seen. You'll agree once you see how they cross Chinese intersections.
 
 What is their story? Did they used to belong to someone? Have they always been stray?
 
-These creatures are like wandering spirits, braving the dark world with their tough underbites. 
+These creatures are like wandering spirits, braving the dark world with their tough underbites.


### PR DESCRIPTION
Hey Kyle! I like the embedded Flikr albums, they look awesome :grinning: I just had a couple super tiny tips! For the categories of a post, it actually separates them by whitespace rather than commas, so if you have

```
categories: photography, china
```

it considers there to be two categories, `photography,` and `china`. It uses the categories for the URL, so if you look at your site right now, the URLs have that comma in them (ie http://kylegraycar.me/photography,/china/2015/10/21/Pets-Snaps.html).

The other super tiny thing was that Markdown is a little different than HTML in that you don't need a closing tag, so you can just have the single `#` at the front of the line to make it a header. Same if you wanted to make a list, it would just be

```
+ list element 1
+ list element 2
+ ...
```

which turns into
- list element 1
- list element 2
- ...

with no need to close the list/elements at all. But ya, I like your pictures a lot :grin: 
